### PR TITLE
Update to latest Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ grunt
 
 (install nodejs for npm support)  
 (first time: npm install -g bower; npm install -g grunt-cli)  
-(to add files to project via bower: bower install bootstrap -S)  
+Bootstrap is now loaded from the CDN at version 5.3.3.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 
         <title>Start</title>
 
-        <link rel="stylesheet" type="text/css" href="css/libraries.css">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="style.css">
         <style type="text/css">
             #mainloading { position: fixed; left: 0; right: 0; top: 0; bottom: 0; z-index: 9999;  background: #486ab4; }
@@ -44,7 +44,7 @@
 
         <!--javascript-->
         <script type="text/javascript" src="js/head.min.js"></script>
-        <script type="text/javascript" src="js/libraries.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
         <script type="text/javascript" src="js/responsive.js"></script>
         <script type="text/javascript" src="js/init.js"></script>
 


### PR DESCRIPTION
## Summary
- Load Bootstrap 5.3.3 from CDN instead of local placeholder files
- Clarify README to note Bootstrap is served from CDN

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c13bb8d5a4832db7ca688a4a390621